### PR TITLE
added discount indicator to product page

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -147,6 +147,37 @@ button {
   margin: 0.5em 0;
 }
 
+.product-card__price {
+  display: flex;
+  align-items: center;
+}
+
+.product-card__final-price {
+  color: #525b0f;
+  font-size: 24px;
+  font-weight: 700;
+  margin-right: 8px;
+}
+
+.product-card__savings-percent {
+  color: #FFFFFF;
+  background-color: #525b0f;
+  font-size: 14px;
+  line-height: 1;
+  text-align: center;
+  font-weight: 600;
+  height: fit-content;
+  padding: 5px 8px;
+  border-radius: 8px;
+  margin-right: 8px;
+}
+
+.product-card__suggested-retail-price {
+  color: gray;
+  text-decoration: line-through;
+  font-size: 16px;
+}
+
 .card__brand {
   font-size: var(--small-font);
 }

--- a/src/js/productDetails.mjs
+++ b/src/js/productDetails.mjs
@@ -22,7 +22,9 @@ function renderProductDetails(productData) {
   img.setAttribute("src", productData.Image);
   img.setAttribute("alt", productData.Name);
 
-  document.getElementById("productPrice").textContent = productData.FinalPrice;
+  document.getElementById("finalPrice").textContent = "$" + productData.FinalPrice;
+  document.getElementById("savingsPercent").textContent = "SAVE " + Math.floor(((productData.SuggestedRetailPrice - productData.FinalPrice) / productData.SuggestedRetailPrice) * 10000) / 100 + "%";
+  document.getElementById("suggestedRetailPrice").textContent = "$" + productData.SuggestedRetailPrice;
   document.getElementById("productColor").textContent = productData.Colors[0].ColorName;
   document.getElementById("productDescription").textContent = productData.DescriptionHtmlSimple;
 }

--- a/src/product_pages/index.html
+++ b/src/product_pages/index.html
@@ -62,7 +62,11 @@
 
         <img class="divider" src="" alt="" id="productImg" />
 
-        <p class="product-card__price" id="productPrice"></p>
+        <p class="product-card__price" id="productPrice">
+          <span class="product-card__final-price" id="finalPrice"></span>
+          <span class="product-card__savings-percent" id="savingsPercent"></span>
+          <span class="product-card__suggested-retail-price" id="suggestedRetailPrice"></span>
+        </p>
 
         <p class="product__color" id="productColor"></p>
 


### PR DESCRIPTION
expanded current #finalPrice <p> tag to include 3 spans, one for finalPrice, one for $ savings, and the last for the suggested retail price. Added additional styles to highlight savings.